### PR TITLE
Fix incorrect indentation

### DIFF
--- a/lorawan-app-connect.md
+++ b/lorawan-app-connect.md
@@ -136,7 +136,7 @@ A default application can be configured using mPower 5.3.x firmware.
     ]
     ```
 
-  * POST /api/v1/lorawan/\<APP-EUI>/up
+* POST /api/v1/lorawan/\<APP-EUI>/up
   * If more than one uplink is available to be sent, up to ten may be sent in an array to the APP-EUI uplink path, this helps if many uplinks are being received in a burst.
   * Field descriptions can be found on [multitech.net](https://www.multitech.net/developer/software/lora/lora-network-server/mqtt-messages/)
     * BODY


### PR DESCRIPTION
Removed the indentation before `POST /api/v1/lorawan/<APP-EUI>/up` so that it is indented on the same level as the other endpoints.